### PR TITLE
feat: add skeleton for stattracker including all methods to be completed

### DIFF
--- a/lib/stattracker.rb
+++ b/lib/stattracker.rb
@@ -1,0 +1,85 @@
+class StatTracker
+  def highest_total_score
+
+  end
+
+  def lowest_total_score
+
+  end
+
+  def percentage_home_wins
+
+  end
+
+  def percentage_visitor_wins
+
+  end
+
+  def percentage_ties
+
+  end
+
+  def count_of_games_by_season
+
+  end
+
+  def average_goals_per_game
+
+  end
+
+  def average_goals_by_season
+
+  end
+
+  def count_of_teams
+
+  end
+
+  def best_offense
+
+  end
+
+  def worst_offense
+
+  end
+
+  def highest_scoring_visitor
+
+  end
+
+  def highest_scoring_home_team
+
+  end
+
+  def lowest_scoring_visitor
+
+  end
+
+  def lowest_scoring_home_team
+
+  end
+
+  def winningest_coach
+
+  end
+
+  def worst_coach
+
+  end
+
+  def most_accurate_team
+
+  end
+
+  def least_accurate_team
+
+  end
+
+  def most_tackles
+
+  end
+
+  def fewest_tackles
+    
+  end
+end

--- a/spec/stattracker.rb
+++ b/spec/stattracker.rb
@@ -1,0 +1,129 @@
+require './lib/stattracker'
+
+RSpec.describe StatTracker do
+  describe "#highest_total_score" do
+    it "" do
+
+    end
+  end
+
+  describe "#lowest_total_score" do
+    it "" do
+      
+    end
+  end
+
+  describe "#percentage_home_wins" do
+    it "" do
+      
+    end
+  end
+
+  describe "#percentage_visitor_wins" do
+    it "" do
+      
+    end
+  end
+
+  describe "#percentage_ties" do
+    it "" do
+      
+    end
+  end
+
+  describe "#count_of_games_by_season" do
+    it "" do
+      
+    end
+  end
+
+  describe "#average_goals_per_game" do
+    it "" do
+      
+    end
+  end
+
+  describe "#average_goals_by_season" do
+    it "" do
+      
+    end
+  end
+
+  describe "#count_of_teams" do
+    it "" do
+      
+    end
+  end
+
+  describe "#best_offense" do
+    it "" do
+      
+    end
+  end
+
+  describe "#worst_offense" do
+    it "" do
+      
+    end
+  end
+
+  describe "#highest_scoring_visitor" do
+    it "" do
+      
+    end
+  end
+
+  describe "#highest_scoring_home_team" do
+    it "" do
+      
+    end
+  end
+
+  describe "#lowest_scoring_visitor" do
+    it "" do
+      
+    end
+  end
+
+  describe "#lowest_scoring_home_team" do
+    it "" do
+      
+    end
+  end
+
+  describe "#winningest_coach" do
+    it "" do
+      
+    end
+  end
+
+  describe "#worst_coach" do
+    it "" do
+      
+    end
+  end
+
+  describe "#most_accurate_team" do
+    it "" do
+      
+    end
+  end
+
+  describe "#least_accurate_team" do
+    it "" do
+      
+    end
+  end
+
+  describe "#most_tackles" do
+    it "" do
+      
+    end
+  end
+
+  describe "#fewest_tackles" do
+    it "" do
+      
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the base StatTracker class, purely as a skeleton for now. Basically, every method listed in iteration 2 now lives in the StatTracker class, so that we can go through and update/add to it as needed while we complete our methods in their respective classes.

I also went ahead and prepped a basic spec file here.