### PR TITLE
Add from csv

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -1,4 +1,14 @@
 class StatTracker
+  attr_reader :game,
+              :game_teams,
+              :teams
+
+  def initialize(game, game_teams, teams)
+    @game = game
+    @game_teams = game_teams
+    @teams = teams
+  end
+
   def highest_total_score
 
   end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -1,12 +1,21 @@
+require 'csv'
+
 class StatTracker
-  attr_reader :game,
+  attr_reader :games,
               :game_teams,
               :teams
 
-  def initialize(game, game_teams, teams)
-    @game = game
+  def initialize(games, game_teams, teams)
+    @games = games
     @game_teams = game_teams
     @teams = teams
+  end
+
+  def self.from_csv(locations)
+    games_contents = locations[:games]
+    game_teams_contents = locations[:game_teams]
+    teams_contents = locations[:teams]
+    StatTracker.new(games_contents, game_teams_contents, teams_contents)
   end
 
   def highest_total_score

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -1,24 +1,39 @@
 require './lib/stat_tracker'
 
-game_path = './data/games.csv'
-team_path = './data/teams.csv'
-game_teams_path = './data/game_teams.csv'
-games_fixture_path = './data/games_fixture.csv'
-games_teams_fixture_path = './data/games_teams_fixture.csv'
-
-
-locations = {
-  games: game_path,
-  teams: team_path,
-  game_teams: game_teams_path,
-  games_fixture_path: games_fixture_path,
-  games_teams_fixture_path: games_teams_fixture_path
-
-}
-
-stat_tracker = StatTracker.from_csv(locations)
+# stat_tracker = StatTracker.from_csv(locations)
+# stat_tracker.game.each
 
 RSpec.describe StatTracker do
+  before(:each) do
+    @game_path = './data/games.csv'
+    @teams_path = './data/teams.csv'
+    @game_teams_path = './data/game_teams.csv'
+    @games_fixture_path = './data/games_fixture.csv'
+    @game_teams_fixture_path = './data/games_teams_fixture.csv'
+    @locations = {
+      games: @game_path,
+      teams: @teams_path,
+      game_teams: @game_teams_path,
+      games_fixture_path: @games_fixture_path,
+      games_teams_fixture_path: @game_teams_fixture_path
+    }
+  end
+  describe "#initialize" do
+    it "exists" do
+      tracker = StatTracker.new("game", "game_teams", "teams")
+
+      expect(tracker).to be_a StatTracker
+    end
+
+    it "has a game, game_team, and teams attribute that is readable" do
+      tracker = StatTracker.new(@game_path, @game_teams_path, @teams_path)
+
+      expect(tracker.game).to eq(@game_path)
+      expect(tracker.game_teams).to eq(@game_teams_path)
+      expect(tracker.teams).to eq(@teams_path)
+    end
+  end
+
   describe "#highest_total_score" do
     it "" do
 

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -1,3 +1,4 @@
+require 'csv'
 require './lib/stat_tracker'
 
 # stat_tracker = StatTracker.from_csv(locations)
@@ -28,9 +29,19 @@ RSpec.describe StatTracker do
     it "has a game, game_team, and teams attribute that is readable" do
       tracker = StatTracker.new(@game_path, @game_teams_path, @teams_path)
 
-      expect(tracker.game).to eq(@game_path)
+      expect(tracker.games).to eq(@game_path)
       expect(tracker.game_teams).to eq(@game_teams_path)
       expect(tracker.teams).to eq(@teams_path)
+    end
+  end
+
+  describe "##from_csv" do
+    it "returns a new instance of a StatTracker object given a hash of filepaths" do
+      tracker = StatTracker.from_csv(@locations)
+
+      expect(tracker.games).to eq(@locations[:games])
+      expect(tracker.game_teams).to eq(@locations[:game_teams])
+      expect(tracker.teams).to eq(@locations[:teams])
     end
   end
 


### PR DESCRIPTION
This adds a basic concept for ##from_csv to the StatTracker class. We originally discussed having from_csv actually read the csv paths provided to it, but I ran into issues with testing that (discussed in Slack).

So, for now, this at least gives us a central location to send our locations in and pull data back out. We'll probably want to take another look at it as we get into more efficient structures and methodology, I think it's more of a stop-gap for now.