### PR TITLE
added tackle method and start of test

### DIFF
--- a/lib/season_stats.rb
+++ b/lib/season_stats.rb
@@ -12,12 +12,34 @@ class SeasonStats < StatDaddy
   #   season 15 = @games.season("20152016")
   #   season 16 = @games.season("20162017")
   #   season 17 = @games.season("20172018")
+ 
 
-  def winningest_coach()
-    # percentage_home_wins
-    # percentage_visitor_wins
-    # percentage_ties
-
+  #this method also works and is what Will sent over.
+  #this needs to then go in to each season in the @game.season and then compare the @game.game_id
+  #with game_teams.game_id so that it breaks down in to six seasons and finds the coach
+  #for each season. 
+  def winningest_coach
+    coach_wins = Hash.new(0)
+    coach_games = Hash.new(0)
+    @game_teams.each do |data|
+     coach = data.head_coach
+     result = data.result
+     if result == "WIN"
+      coach_wins[coach] += 1
+     end
+     coach_games[coach] += 1
+    end
+    highest_win_percentage = 0.0
+    winningest_coach = nil
+    coach_wins.each do |coach, wins|
+     win_percentage = wins.to_f / coach_games[coach]
+     if win_percentage > highest_win_percentage
+      highest_win_percentage = win_percentage
+      winningest_coach = coach
+     end
+    end
+    winningest_coach
+   end
   #   @games.team_id.each do |data|
   #     loss = data.result("loss")
   #     win = data.result("win")
@@ -30,10 +52,10 @@ class SeasonStats < StatDaddy
   # end
 
    
-  end
+  # end
 
-    # Name of the Coach with the worst win percentage for the season
-  end
+  #   # Name of the Coach with the worst win percentage for the season
+  # end
 
   def most_accurate_team()
     # Name of the Team with the best ratio of shots to goals for the season
@@ -43,17 +65,34 @@ class SeasonStats < StatDaddy
     # Name of the Team with the worst ratio of shots to goals for the season
   end
 
+#this tackles method works if you run rspec but this now needs to have the
+#tackles team string like "5" (look at the #most_tackles spec tests) return the name of the team
+# the name of the team is in the teams.csv so we have to call in to that
+# something like comparing @team.team_id
+#and then replacing the instance of @game_teams.team_id to @team.team_name
+
+
+#either way, this method can be used for both methods below eventually, just have to 
+#flesh out what that means for each season as well.
+#season is only listed in the games.csv so something like @game.season to compile 
+#each seasons and then compare somehow the seasons with the game_id instances in
+#both @game and @game_teams. 
+  def tackles
+    tackles_total = Hash.new(0)
+    @game_teams.each do |data|
+      team_id = data.team_id
+      tackles = data.tackles.to_i
+      tackles_total[team_id] += tackles
+    end
+    tackles_total
+  end
+
+  # Name of the Team with the most tackles in the season
   def most_tackles
     team_tackles = []
-    # Name of the Team with the most tackles in the season
-    @games_teams_fixture_path.each do |data|
-      @team_id = data.team_id.to_i
-      @tackles = data.tackles.to_i
-      # team_tackles[@team_id] += @tackles
-      @team_goals.each do |team_id, tackles|
-        puts "Team ID #{team_id}: Total Tackles - #{tackles}"
-      end
-      tackles
+    tackles
+    @team_goals.each do |team_id, tackles|
+      puts "Team ID #{team_id}: Total Tackles - #{tackles}"
     end
   end
 

--- a/spec/season_stats_spec.rb
+++ b/spec/season_stats_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe SeasonStats do
 
   describe "#winningest_coach" do
     it "can name the coach with the best win percentage of the season" do
+      # require 'pry';binding.pry
+    
       expect(@season_stats.winningest_coach("20132014")).to eq "Claude Julien"
       expect(@season_stats.winningest_coach("20142015")).to eq "Alain Vigneault"
     end
@@ -57,9 +59,10 @@ RSpec.describe SeasonStats do
   end
 
   describe "#most_tackles" do
-    xit "can name the team with the most tackles in the season" do
-      expect(@season_stats.most_tackles("20132014")).to eq "FC Cincinnati"
-      expect(@season_stats.most_tackles("20142015")).to eq "Seattle Sounders FC"
+    it "can name the team with the most tackles in the season" do
+      expect(@season_stats.tackles).to eq "5"=>14657
+      # expect(@season_stats.most_tackles("20132014")).to eq "FC Cincinnati"
+      # expect(@season_stats.most_tackles("20142015")).to eq "Seattle Sounders FC"
     end
   end
 


### PR DESCRIPTION
also the winningest_coach method start along with notes to help guide next steps


Got the tackle method to work, at least so it returns a hash of the team numbers with the total amount of tackles. I started a test to relate to the tackle method in the most_tackles spec tests with the return of the highest tackles total. This only works as a test and needs to have that data also changed to return the team name by checking the team.csv and also needs to break down tackles by season, which requires the games.csv to access the only csv that has the seasons info.

Also added in the winningest_coach method that Will worked on and then we refactored a bit to get it to start working somewhat. This also needs to do similar stuff like the tackle method. It needs to break down this data in to seasons which is only possible by getting in to the games.csv, and then check the @game.game_id and the @game_teams.game_id against each other somehow. 