### PR TITLE
Weston game stats2.0

### DIFF
--- a/lib/game_stats.rb
+++ b/lib/game_stats.rb
@@ -5,11 +5,6 @@ require_relative "stat_daddy"
 # binding.pry
 class GameStats < StatDaddy
 
-  # def initialize(locations)
-  #   @games = CSV.open(locations[:games], headers: true, header_converters: :symbol).map {|game| Game.new(game)}
-  #   # binding.pry
-  # end
-
   def highest_total_score
     highest_total_score = 0
 
@@ -52,7 +47,7 @@ class GameStats < StatDaddy
       total_games += 1
     end
 
-    home_win_percentage = (home_wins.to_f / total_games) * 100
+    home_win_percentage = (home_wins.to_f / total_games) 
     home_win_percentage.round(2)
   end
 
@@ -71,7 +66,7 @@ class GameStats < StatDaddy
       total_games += 1
     end
 
-    away_win_percentage = (away_wins.to_f / total_games) * 100
+    away_win_percentage = (away_wins.to_f / total_games) 
     away_win_percentage.round(2)
   end
 
@@ -90,7 +85,7 @@ class GameStats < StatDaddy
       total_games += 1
     end
 
-    tie_percentage = (ties.to_f / total_games) * 100
+    tie_percentage = (ties.to_f / total_games) 
     tie_percentage.round(2)
   end
 
@@ -102,7 +97,7 @@ class GameStats < StatDaddy
       games_by_season[season] += 1 # increments count of games for that season by 1
     end
 
-    games_by_season # return hash which contains count of games for each season
+    games_by_season 
   end
 
   def average_goals_per_game
@@ -133,9 +128,11 @@ class GameStats < StatDaddy
 
     average_goals = {} # initialize empty hash for average goals
     goals_by_season.each do |season, total_goals| # iterate through season and goals
-      total_games = total_goals_by_season[season] # 
+      total_games = total_goals_by_season[season] 
       average_goals[season] = total_goals.to_f / total_games
     end
-    average_goals
+
+    round_average_goals = average_goals.transform_values { |value| value.round(2) }
+    round_average_goals
   end
 end

--- a/lib/game_stats.rb
+++ b/lib/game_stats.rb
@@ -123,7 +123,7 @@ class GameStats < StatDaddy
       goals = data.home_goals.to_i + data.away_goals.to_i # convert to integers so string to integer doesnt pop up
       goals_by_season[season] += goals 
       
-      total_goals_by_season[season] += 1 
+      total_goals_by_season[season] += 1 # count of games for particular season 
     end
 
     average_goals = {} # initialize empty hash for average goals

--- a/spec/game_stats_spec.rb
+++ b/spec/game_stats_spec.rb
@@ -45,21 +45,21 @@ RSpec.describe GameStats do
   describe "#percentage_home_wins" do
     it "finds the percentage of games that a home team has won (rounded to the nearest 100th)" do
       # binding.pry
-      expect(@game_stats.percentage_home_wins).to eq(60.0)
+      expect(@game_stats.percentage_home_wins).to eq(0.6)
     end
   end
 
   describe "#percentage_visitor_wins" do
     it "finds the percentage of games that a visitor has won (rounded to the nearest 100th)" do
       # binding.pry
-      expect(@game_stats.percentage_visitor_wins).to eq(31.43)
+      expect(@game_stats.percentage_visitor_wins).to eq(0.31)
     end
   end
   
   describe "#percentage_ties" do
     it "finds the percentage of games that has resulted in a tie (rounded to the nearest 100th)" do
       # binding.pry
-      expect(@game_stats.percentage_ties).to eq(8.57)
+      expect(@game_stats.percentage_ties).to eq(0.09)
     end
   end
 
@@ -91,11 +91,11 @@ RSpec.describe GameStats do
       # binding.pry
       expected_hash = 
       {
+        "20122013"=>4.13,
         "20132014"=>4.25,
-        "20122013"=>4.125,
-        "20142015"=>3.857142857142857,
+        "20142015"=>3.86,
+        "20152016"=>3.67,
         "20162017"=>4.5,
-        "20152016"=>3.6666666666666665,
         "20172018"=>4.0
       }
       expect(@game_stats.average_goals_by_season).to eq(expected_hash)

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -72,11 +72,11 @@ RSpec.describe StatTracker do
     it 'creates a hash with season names (e.g. 20122013) as keys and counts of games as values' do
       expected_hash = 
       {
-        "20132014"=>806,
-        "20122013"=>1317,
+        "20122013"=>806,
+        "20132014"=>1323,
         "20142015"=>1319,
-        "20162017"=>1321,
-        "20152016"=>1323,
+        "20152016"=>1321,
+        "20162017"=>1317,
         "20172018"=>1355
       }
       expect(@tracker.count_of_games_by_season).to eq(expected_hash)
@@ -95,11 +95,11 @@ RSpec.describe StatTracker do
       # binding.pry
       expected_hash = 
       {
-        "20132014"=>4.12,
-        "20122013"=>4.23,
+        "20122013"=>4.12,
+        "20132014"=>4.19,
         "20142015"=>4.14,
-        "20162017"=>4.16,
-        "20152016"=>4.19,
+        "20152016"=>4.16,
+        "20162017"=>4.23,
         "20172018"=>4.44
       }
       expect(@tracker.average_goals_by_season).to eq(expected_hash)
@@ -107,84 +107,84 @@ RSpec.describe StatTracker do
   end
 
   describe "#count_of_teams" do
-    xit "returns total number of teams in the data" do
+    it "returns total number of teams in the data" do
       expect(@tracker.count_of_teams).to be(32)
     end
   end
 
   describe "#best_offense" do
-    xit "returns name of team with highest avg goals scored per game across all seasons" do
+    it "returns name of team with highest avg goals scored per game across all seasons" do
       expect(@tracker.best_offense).to eq("Reign FC")
     end
   end
 
   describe "#worst_offense" do
-    xit "returns name of team with lowest avg goals per game across all seasons" do
+    it "returns name of team with lowest avg goals per game across all seasons" do
       expect(@tracker.worst_offense).to eq("Utah Royals FC")
     end
   end
 
   describe "#highest_scoring_visitor" do
-    xit "returns name of team with highest avg score per game across all seasons while away" do
+    it "returns name of team with highest avg score per game across all seasons while away" do
       expect(@tracker.highest_scoring_visitor).to eq("FC Dallas")
     end
   end
 
   describe "#highest_scoring_home_team" do
-    xit "returns name of team with highest avg score per game across all seasons while home" do
+    it "returns name of team with highest avg score per game across all seasons while home" do
       expect(@tracker.highest_scoring_home_team).to eq("Reign FC")
     end
   end
 
   describe "#lowest_scoring_visitor" do
-    xit "returs name of team with lowest avg score per game across all seasons while a visitor" do
+    it "returs name of team with lowest avg score per game across all seasons while a visitor" do
       expect(@tracker.lowest_scoring_visitor).to eq("San Jose Earthquakes")
     end
   end
 
   describe "#lowest_scoring_home_team" do
-    xit "returns name of team with lowest avg score per game across all seasons while home" do
+    it "returns name of team with lowest avg score per game across all seasons while home" do
       expect(@tracker.lowest_scoring_home_team).to eq("Utah Royals FC")
     end
   end
 
   describe "#winningest_coach" do
-    xit "can name the coach with the best win percentage of the season" do
+    it "can name the coach with the best win percentage of the season" do
       expect(@tracker.winningest_coach("20132014")).to eq "Claude Julien"
       expect(@tracker.winningest_coach("20142015")).to eq "Alain Vigneault"
     end
   end 
 
   describe "#worst_coach" do
-    xit "can name the coach with the worst percentage for the season" do
+    it "can name the coach with the worst percentage for the season" do
       expect(@tracker.worst_coach("20132014")).to eq "Peter Laviolette"
       expect(@tracker.worst_coach("20142015")).to eq("Craig MacTavish").or(eq("Ted Nolan"))
     end
   end
 
   describe "#most_accurate_team" do
-    xit "can name the team with the best raiot of shots to goals for the season" do
+    it "can name the team with the best raiot of shots to goals for the season" do
       expect(@tracker.most_accurate_team("20132014")).to eq "Real Salt Lake"
       expect(@tracker.most_accurate_team("20142015")).to eq "Toronto FC"
     end
   end
 
   describe "#least_accurate_team" do
-    xit "can name the team with the worst ratio of shots to goals for the season" do
+    it "can name the team with the worst ratio of shots to goals for the season" do
       expect(@tracker.least_accurate_team("20132014")).to eq "New York City FC"
       expect(@tracker.least_accurate_team("20142015")).to eq "Columbus Crew SC"
     end
   end
 
   describe "#most_tackles" do
-    xit "can name the team with the most tackles in the season" do
+    it "can name the team with the most tackles in the season" do
       expect(@tracker.most_tackles("20132014")).to eq "FC Cincinnati"
       expect(@tracker.most_tackles("20142015")).to eq "Seattle Sounders FC"
     end
   end
 
   describe "#fewest_tackles" do
-    xit "can name the team with the fewest tackles in the season" do
+    it "can name the team with the fewest tackles in the season" do
       expect(@tracker.fewest_tackles("20132014")).to eq "Atlanta United"
       expect(@tracker.fewest_tackles("20142015")).to eq "Orlando City SC"
     end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -107,84 +107,84 @@ RSpec.describe StatTracker do
   end
 
   describe "#count_of_teams" do
-    it "returns total number of teams in the data" do
+    xit "returns total number of teams in the data" do
       expect(@tracker.count_of_teams).to be(32)
     end
   end
 
   describe "#best_offense" do
-    it "returns name of team with highest avg goals scored per game across all seasons" do
+    xit "returns name of team with highest avg goals scored per game across all seasons" do
       expect(@tracker.best_offense).to eq("Reign FC")
     end
   end
 
   describe "#worst_offense" do
-    it "returns name of team with lowest avg goals per game across all seasons" do
+    xit "returns name of team with lowest avg goals per game across all seasons" do
       expect(@tracker.worst_offense).to eq("Utah Royals FC")
     end
   end
 
   describe "#highest_scoring_visitor" do
-    it "returns name of team with highest avg score per game across all seasons while away" do
+    xit "returns name of team with highest avg score per game across all seasons while away" do
       expect(@tracker.highest_scoring_visitor).to eq("FC Dallas")
     end
   end
 
   describe "#highest_scoring_home_team" do
-    it "returns name of team with highest avg score per game across all seasons while home" do
+    xit "returns name of team with highest avg score per game across all seasons while home" do
       expect(@tracker.highest_scoring_home_team).to eq("Reign FC")
     end
   end
 
   describe "#lowest_scoring_visitor" do
-    it "returs name of team with lowest avg score per game across all seasons while a visitor" do
+    xit "returs name of team with lowest avg score per game across all seasons while a visitor" do
       expect(@tracker.lowest_scoring_visitor).to eq("San Jose Earthquakes")
     end
   end
 
   describe "#lowest_scoring_home_team" do
-    it "returns name of team with lowest avg score per game across all seasons while home" do
+    xit "returns name of team with lowest avg score per game across all seasons while home" do
       expect(@tracker.lowest_scoring_home_team).to eq("Utah Royals FC")
     end
   end
 
   describe "#winningest_coach" do
-    it "can name the coach with the best win percentage of the season" do
+    xit "can name the coach with the best win percentage of the season" do
       expect(@tracker.winningest_coach("20132014")).to eq "Claude Julien"
       expect(@tracker.winningest_coach("20142015")).to eq "Alain Vigneault"
     end
   end 
 
   describe "#worst_coach" do
-    it "can name the coach with the worst percentage for the season" do
+    xit "can name the coach with the worst percentage for the season" do
       expect(@tracker.worst_coach("20132014")).to eq "Peter Laviolette"
       expect(@tracker.worst_coach("20142015")).to eq("Craig MacTavish").or(eq("Ted Nolan"))
     end
   end
 
   describe "#most_accurate_team" do
-    it "can name the team with the best raiot of shots to goals for the season" do
+    xit "can name the team with the best raiot of shots to goals for the season" do
       expect(@tracker.most_accurate_team("20132014")).to eq "Real Salt Lake"
       expect(@tracker.most_accurate_team("20142015")).to eq "Toronto FC"
     end
   end
 
   describe "#least_accurate_team" do
-    it "can name the team with the worst ratio of shots to goals for the season" do
+    xit "can name the team with the worst ratio of shots to goals for the season" do
       expect(@tracker.least_accurate_team("20132014")).to eq "New York City FC"
       expect(@tracker.least_accurate_team("20142015")).to eq "Columbus Crew SC"
     end
   end
 
   describe "#most_tackles" do
-    it "can name the team with the most tackles in the season" do
+    xit "can name the team with the most tackles in the season" do
       expect(@tracker.most_tackles("20132014")).to eq "FC Cincinnati"
       expect(@tracker.most_tackles("20142015")).to eq "Seattle Sounders FC"
     end
   end
 
   describe "#fewest_tackles" do
-    it "can name the team with the fewest tackles in the season" do
+    xit "can name the team with the fewest tackles in the season" do
       expect(@tracker.fewest_tackles("20132014")).to eq "Atlanta United"
       expect(@tracker.fewest_tackles("20142015")).to eq "Orlando City SC"
     end


### PR DESCRIPTION
Few things here...

Fix: rounding to appropriate decimal fixed on all 3 percentage tests for home wins, visitor wins and ties. Float numbers input to follow harness IE (0.44 instead of 44% to follow harness) 

Fix: rounding on avg_goals_by season to follow harness and eval requirements 

Fix: Keys and Values in expected hash needed to be reordered. Test fixed. Passes and follows harness expected outputs with a slight re ordering of years to follow chronological placement IE 20122013 -> 20132014 instead of 20122013 -> 20162017.  Passes both ways but chronological makes more sense for data readability 